### PR TITLE
Fix exporting the class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+const covoit = require('./core/covoit')
+exports.covoit = covoit;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "dev": "./node_modules/.bin/nodemon examples/example-1.js",
     "test": "mocha",
     "test:live": "mocha -w",
-    "doc": "node server.js",
     "preinstall": "npm doctor"
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -1,1 +1,0 @@
-console.log('have to code something for a nice documentation')


### PR DESCRIPTION
When `npm install` it should export the class to the user, but nothing seems to be exported. Let's see how it works now.